### PR TITLE
Update cwagent-fluentd-quickstart.yaml

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -146,6 +146,8 @@ spec:
             - name: devdisk
               mountPath: /dev/disk
               readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
       volumes:
         - name: cwagentconfig
           configMap:
@@ -598,6 +600,8 @@ spec:
             - name: dmesg
               mountPath: /var/log/dmesg
               readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
Updated with Linux Node Selector for issue 14

*Issue#14

*Description of changes:*

Added Linux Nodeselector so that the pods only run on Linux Worker nodes as there currently isn't a fluentd image for Windows (raised with AWS) The pods will fail to run on Windows worker nodes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
